### PR TITLE
Update palette creation for translation purposes

### DIFF
--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -121,27 +121,32 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
       separator: true
     },
     'create.start-event': createAction(
-      'bpmn:StartEvent', 'event', 'bpmn-icon-start-event-none'
+      'bpmn:StartEvent', 'event', 'bpmn-icon-start-event-none',
+      translate('Create Start Event')
     ),
     'create.intermediate-event': createAction(
       'bpmn:IntermediateThrowEvent', 'event', 'bpmn-icon-intermediate-event-none',
       translate('Create Intermediate/Boundary Event')
     ),
     'create.end-event': createAction(
-      'bpmn:EndEvent', 'event', 'bpmn-icon-end-event-none'
+      'bpmn:EndEvent', 'event', 'bpmn-icon-end-event-none',
+      translate('Create End Event')
     ),
     'create.exclusive-gateway': createAction(
       'bpmn:ExclusiveGateway', 'gateway', 'bpmn-icon-gateway-none',
       translate('Create Gateway')
     ),
     'create.task': createAction(
-      'bpmn:Task', 'activity', 'bpmn-icon-task'
+      'bpmn:Task', 'activity', 'bpmn-icon-task',
+      translate('Create Task')
     ),
     'create.data-object': createAction(
-      'bpmn:DataObjectReference', 'data-object', 'bpmn-icon-data-object'
+      'bpmn:DataObjectReference', 'data-object', 'bpmn-icon-data-object',
+      translate('Create DataObject Reference')
     ),
     'create.data-store': createAction(
-      'bpmn:DataStoreReference', 'data-store', 'bpmn-icon-data-store'
+      'bpmn:DataStoreReference', 'data-store', 'bpmn-icon-data-store',
+      translate('Create DataStore Reference')
     ),
     'create.subprocess-expanded': createAction(
       'bpmn:SubProcess', 'activity', 'bpmn-icon-subprocess-expanded',


### PR DESCRIPTION
For better translation to the some languages with Nominative/Genitive/etc cases (e.g. russian). It is the more preferable way - not to construct title attributes for createActions dynamically, but translate them as whole phrases.
